### PR TITLE
Remove hardcoded font size

### DIFF
--- a/styles/styleguide.less
+++ b/styles/styleguide.less
@@ -4,7 +4,6 @@
 .styleguide {
   position: relative;
   overflow: auto;
-  font-size: 12px;
 
   & > section {
     &.bordered {


### PR DESCRIPTION
I'd like to be able to inherit the font size where I can. Not sure if this goes counter to Atom theming (still learning it), but the fixed font size was really confusing.