### PR TITLE
Document the required import for UI variables.

### DIFF
--- a/lib/styleguide-view.coffee
+++ b/lib/styleguide-view.coffee
@@ -14,7 +14,7 @@ class StyleguideView extends ScrollView
         @p 'This exercises all UI components and acts as a styleguide.'
 
       @exampleSection 'variables', 'Variables', ->
-        @p => @raw '''Use these UI variables in your package's stylesheets. They are set by UI themes and therefore your package will match the overall look.'''
+        @p => @raw '''Use these UI variables in your package's stylesheets. They are set by UI themes and therefore your package will match the overall look. Make sure to @import 'ui-variables' in your stylesheets to use these variables.'''
 
         @div class: 'variables-group', =>
           @h2 'Text colors'


### PR DESCRIPTION
There's no error if you use the UI variables without importing 'ui-variables'. Instead, you get colors that don't match the style guide and it's not obvious why that's the case.