### PR TITLE
Add Accordion Menu

### DIFF
--- a/lib/styleguide-view.js
+++ b/lib/styleguide-view.js
@@ -761,6 +761,34 @@ export default class StyleguideView {
             `)}
           </StyleguideSection>
 
+          <StyleguideSection onDidInitialize={this.didInitializeSection.bind(this)} name='accordion' title='Accordion'>
+            <p>A menu with collapsable content.</p>
+            {this.renderExampleHTML(dedent`
+              <menu class='accordion'>
+                <details class='accordion-item' open>
+                  <summary class='accordion-header'>Item 1</summary>
+                  <main class='accordion-content'>Content 1</main>
+                </details>
+                <details class='accordion-item'>
+                  <summary class='accordion-header'>Item 2</summary>
+                  <main class='accordion-content'>
+                    <input class='input-checkbox' type='checkbox' checked> Checkbox
+                  </main>
+                </details>
+                <details class='accordion-item'>
+                  <summary class='accordion-header'>Item 3</summary>
+                  <main class='accordion-content'></main>
+                </details>
+                <details class='accordion-item'>
+                  <summary class='accordion-header'>Item 4</summary>
+                  <main class='accordion-content'>
+                    <input class='input-range' type='range'>
+                  </main>
+                </details>
+              </menu>
+            `)}
+          </StyleguideSection>
+
           <StyleguideSection onDidInitialize={this.didInitializeSection.bind(this)} name='list-group' title='List Group'>
             <p>Use for anything that requires a list.</p>
             {this.renderExampleHTML(dedent`


### PR DESCRIPTION
### Description of the Change

This adds the Accordion Menu that got introduced in https://github.com/atom/atom-ui/pull/14

![accordion](https://cloud.githubusercontent.com/assets/378023/22718103/da7a8590-ede1-11e6-8a97-ad67b6df9392.gif)

### Alternate Designs

It could also be considered not using the `<details>` element and re-implement it as an Edge component. But for now it's CSS only and the package author has to write/generate the markup.

### Benefits

Helps package authors add collapsable sections, probably best used in a side panel.

### Possible Drawbacks

Some maintenance cost, but should be neglectable.

### Applicable Issues

Depends on https://github.com/atom/atom-ui/pull/14
