### PR TITLE
Tokenize HTML as HTML without beautification

### DIFF
--- a/lib/styleguide-view.js
+++ b/lib/styleguide-view.js
@@ -3,7 +3,6 @@
 
 import etch from 'etch'
 import dedent from 'dedent'
-import {html as beautifyHtml} from 'js-beautify'
 import CodeBlock from './code-block'
 import StyleguideSection from './styleguide-section'
 import ExampleSelectListView from './example-select-list-view'
@@ -1251,7 +1250,7 @@ export default class StyleguideView {
       <div className='example'>
         <div className='example-rendered' innerHTML={html} />
         <div className='example-code show-example-html'>
-          <CodeBlock cssClass='example-html' grammarScopeName='text.xml' code={beautifyHtml(html)} />
+          <CodeBlock cssClass='example-html' grammarScopeName='text.xml' code={html} />
         </div>
       </div>
     )

--- a/lib/styleguide-view.js
+++ b/lib/styleguide-view.js
@@ -1250,7 +1250,7 @@ export default class StyleguideView {
       <div className='example'>
         <div className='example-rendered' innerHTML={html} />
         <div className='example-code show-example-html'>
-          <CodeBlock cssClass='example-html' grammarScopeName='text.xml' code={html} />
+          <CodeBlock cssClass='example-html' grammarScopeName='text.html.basic' code={html} />
         </div>
       </div>
     )

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "atom-select-list": "^0.1.0",
     "dedent": "^0.7.0",
     "etch": "0.9.0",
-    "highlights": "^3.1.1",
-    "js-beautify": "1.6.14"
+    "highlights": "^3.1.1"
   },
   "deserializers": {
     "StyleguideView": "createStyleguideView"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The first commit removes the `js-beautify` dependency.  All our HTML can already be considered "beautified".  I did a manual visual check and cannot find any differences between the raw and beautified HTML output.  The second commit tokenizes HTML as HTML instead of...XML?

### Alternate Designs

None.

### Benefits

More accurate highlighting through Highlights, as well as one less dependency to install and require.

### Possible Drawbacks

Perhaps js-beautify was doing something important.

### Applicable Issues

None.