### PR TITLE
Fix list-group selection

### DIFF
--- a/lib/styleguide-view.js
+++ b/lib/styleguide-view.js
@@ -768,13 +768,13 @@ export default class StyleguideView {
             <p>Use for anything that requires a list.</p>
             {this.renderExampleHTML(dedent`
               <ul class='list-group'>
-                <li class='list-item'>Normal item</li>
-                <li class='list-item selected'>This is the Selected item</li>
-                <li class='list-item text-subtle'>Subtle</li>
-                <li class='list-item text-info'>Info</li>
-                <li class='list-item text-success'>Success</li>
-                <li class='list-item text-warning'>Warning</li>
-                <li class='list-item text-error'>Error</li>
+                <li class='list-item'><span>Normal item</span></li>
+                <li class='list-item selected'><span>This is the Selected item</span></li>
+                <li class='list-item text-subtle'><span>Subtle</span></li>
+                <li class='list-item text-info'><span>Info</span></li>
+                <li class='list-item text-success'><span>Success</span></li>
+                <li class='list-item text-warning'><span>Warning</span></li>
+                <li class='list-item text-error'><span>Error</span></li>
               </ul>
             `)}
 


### PR DESCRIPTION
### Description of the Change

This wraps the text in `list-groups` with a `<span>`. It's needed so that the selection doesn't cover the text.

### Benefits

Text is visible for selected items.

### Applicable Issues

Fixes #67
