### PR TITLE
Use TextEditors to render code blocks, remove highlights

### DIFF
--- a/lib/code-block.js
+++ b/lib/code-block.js
@@ -1,22 +1,17 @@
-/** @babel */
+const {TextEditor} = require('atom')
 
-import Highlights from 'highlights'
-
-export default class CodeBlock {
+module.exports =
+class CodeBlock {
   constructor (props) {
-    this.highlighter = new Highlights({registry: atom.grammars, scopePrefix: 'syntax--'})
-    this.wrapperElement = document.createElement('div')
+    this.editor = new TextEditor({readonly: true, keyboardInputEnabled: false})
+    this.element = document.createElement('div')
+    this.element.appendChild(this.editor.getElement())
+    atom.grammars.assignLanguageMode(this.editor, props.grammarScopeName)
     this.update(props)
   }
 
-  update ({cssClass, grammarScopeName, code}) {
-    this.wrapperElement.innerHTML = this.highlighter.highlightSync({fileContents: code, scopeName: grammarScopeName})
-    this.element = this.wrapperElement.children[0]
-    this.element.classList.remove('editor') // The `editor` class messes things up as `.editor` has absolutely positioned lines
+  update ({cssClass, code}) {
+    this.editor.setText(code)
     this.element.classList.add(cssClass)
-    const fontFamily = atom.config.get('editor.fontFamily')
-    if (fontFamily) {
-      this.element.style.fontFamily = fontFamily
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "dependencies": {
     "atom-select-list": "^0.7.0",
     "dedent": "^0.7.0",
-    "etch": "0.9.0",
-    "highlights": "^3.1.1"
+    "etch": "0.9.0"
   },
   "deserializers": {
     "StyleguideView": "createStyleguideView"


### PR DESCRIPTION
This PR updates the style guide to render HTML code blocks using TextEditors. This way, we follow Atom's normal logic for selecting a grammar based on the `core.useTreeSitterParsers` setting. This removes a dependency on `highlights`.

Fixes atom/atom#16581