### PR TITLE
⬆️ standard@12.0.1

### DIFF
--- a/lib/code-block.js
+++ b/lib/code-block.js
@@ -1,16 +1,16 @@
-const {TextEditor} = require('atom')
+const { TextEditor } = require('atom')
 
 module.exports =
 class CodeBlock {
   constructor (props) {
-    this.editor = new TextEditor({readonly: true, keyboardInputEnabled: false})
+    this.editor = new TextEditor({ readonly: true, keyboardInputEnabled: false })
     this.element = document.createElement('div')
     this.element.appendChild(this.editor.getElement())
     atom.grammars.assignLanguageMode(this.editor, props.grammarScopeName)
     this.update(props)
   }
 
-  update ({cssClass, code}) {
+  update ({ cssClass, code }) {
     this.editor.setText(code)
     this.element.classList.add(cssClass)
   }

--- a/lib/styleguide-section.js
+++ b/lib/styleguide-section.js
@@ -22,14 +22,14 @@ export default class StyleguideSection {
         className += ' collapsed'
       }
       return (
-        <section className={className} dataset={{name: this.name}}>
+        <section className={className} dataset={{ name: this.name }}>
           <h1 className='section-heading' onclick={() => this.toggle()}>{this.title}</h1>
           {this.children}
         </section>
       )
     } else {
       return (
-        <section className='bordered collapsed' dataset={{name: this.name}}>
+        <section className='bordered collapsed' dataset={{ name: this.name }}>
           <h1 className='section-heading' onclick={() => this.toggle()}>{this.title}</h1>
         </section>
       )

--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -1,4 +1,4 @@
-const {CompositeDisposable} = require('atom')
+const { CompositeDisposable } = require('atom')
 let StyleguideView = null
 
 const STYLEGUIDE_URI = 'atom://styleguide'
@@ -7,7 +7,7 @@ module.exports = {
   activate () {
     this.subscriptions = new CompositeDisposable()
     this.subscriptions.add(atom.workspace.addOpener(filePath => {
-      if (filePath === STYLEGUIDE_URI) return this.createStyleguideView({uri: STYLEGUIDE_URI})
+      if (filePath === STYLEGUIDE_URI) return this.createStyleguideView({ uri: STYLEGUIDE_URI })
     }))
     this.subscriptions.add(atom.commands.add('atom-workspace', 'styleguide:show', () => atom.workspace.open(STYLEGUIDE_URI))
     )

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "atom": "*"
   },
   "devDependencies": {
-    "standard": "^10.0.3"
+    "standard": "^12.0.1"
   },
   "standard": {
     "env": {

--- a/spec/styleguide-spec.js
+++ b/spec/styleguide-spec.js
@@ -1,4 +1,4 @@
-const {it, fit, ffit, beforeEach, afterEach} = require('./async-spec-helpers') // eslint-disable-line no-unused-vars
+const { it, fit, ffit, beforeEach, afterEach } = require('./async-spec-helpers') // eslint-disable-line no-unused-vars
 
 describe('Style Guide', () => {
   beforeEach(async () => {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This updates standard to v12.0.1. See the changelogs for [v11](https://standardjs.com/changelog.html#1100---2018-02-18) and [v12](https://standardjs.com/changelog.html#1200---2018-08-28). I also ran `npx standard --fix` to ensure the codebase conformed with standard@12 formatting before committing.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

N/A

### Benefits

<!-- What benefits will be realized by the code change? -->

Keeps the code linting dependency up-to-date.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

I noticed the bracket spacing was changed in a recent version of Standard.

```js
// standard@10
let {property} = object
let myObject = {key: value}

// standard@12
let { property } = object
let myObject = { key: value }
```

I could see updating to standard@12 across a variety of the atom packages would change this formatting across the board, and maybe that's a larger discussion for the atom team to have. 🤔 

### Applicable Issues

<!-- Enter any applicable Issues here -->

N/A
