### PR TITLE
correct section on tooltips

### DIFF
--- a/lib/styleguide-view.js
+++ b/lib/styleguide-view.js
@@ -1140,10 +1140,10 @@ export default class StyleguideView {
 
           <StyleguideSection onDidInitialize={this.didInitializeSection.bind(this)} name='tooltips' title='Tooltips'>
             <p>
-              You do not create the markup directly. You call
-              <code>{`element.setTooltip(title, {command, commandElement}={})`}</code>.
-              Passing in a <code>command</code> (like <code>find-and-replace:show-find</code>) and
-              <code>commandElement</code> (context for the command) will yield a tip with a keystroke.
+              You do not create the markup directly. You call <code>{`atom.tooltips.add(element, {title})`}</code>.
+              Further options can be used to specify a <code>command</code>, which will yield a tip with a keystroke.
+              See <a href="https://flight-manual.atom.io/api/v1.42.0/TooltipManager/"><code>TooltipManager</code></a>
+              in the Atom Flight Manual for details.
             </p>
 
             {this.renderExampleHTML(dedent`


### PR DESCRIPTION
### Description of the Change

This change implements the correction of the section on tooltips, as discussed with @Arcanemagus in issue #75.

I did not change the HTML code example. I'm not sure how useful the code is here though, since as I understand it the respective elements are created by the TooltipManager.

### Alternate Designs

Well, I guess the wording could be different. ;)

### Benefits

Users receive correct information on how to add tooltips.

### Possible Drawbacks

None that I can see.

### Applicable Issues

#75 
